### PR TITLE
Fix 'env var' error in verification action and 'download artifact' error in merge action

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -33,6 +33,7 @@ jobs:
       - name: check if verification action was triggered by a pull request
         run: |
           trigger_info=$(cat trigger_info.txt)
+          echo $trigger_info
           if [[ "$trigger_info" == "pull_request" || "$trigger_info" == "pull_request_target" ]]; then
             echo "This workflow was triggered by a pull request. Do not update url in read me."
             TRIGGER_INFO='pull request'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -120,7 +120,4 @@ jobs:
           git add README.md
           git commit -m "update README with new artifact url $ARTIFACT_URL"
           git push
-        # run during a pull request
-        # if: env.TRIGGER_INFO != 'pull_request'
-        # run after a pull request
         if: github.repository_owner == 'SiEPIC' && env.TRIGGER_INFO != 'pull request'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -28,6 +28,7 @@ jobs:
           name: verification-trigger
           path: .
           search_artifacts: true
+        if: github.event_name != 'workflow_dispatch'
 
       - name: check if verification action was triggered by a pull request
         run: |
@@ -38,6 +39,14 @@ jobs:
           else
             echo "This workflow was not triggered by a pull request. Continue with merge and update url in read me."
           fi
+        if: github.event_name != 'workflow_dispatch'
+
+      # there is only an artifact to download if this action is triggered after the verification action
+      # if it is manually triggered we set the var trigger_info manually 
+      - name: if this action was manually triggered set trigger_info var
+        run: |
+          trigger_info='workflow_dispatch'
+          echo "TRIGGER_INFO=$trigger_info" >> $GITHUB_ENV
 
         # can also specify python version if needed
       - name: setup python

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -33,9 +33,10 @@ jobs:
       - name: check if verification action was triggered by a pull request
         run: |
           trigger_info=$(cat trigger_info.txt)
-          if [[ "$trigger_info" == "pull_request" ]]; then
+          if [[ "$trigger_info" == "pull_request" || "$trigger_info" == "pull_request_target" ]]; then
             echo "This workflow was triggered by a pull request. Do not update url in read me."
-            echo "TRIGGER_INFO=$trigger_info" >> $GITHUB_ENV
+            TRIGGER_INFO='pull request'
+            echo "TRIGGER_INFO=$TRIGGER_INFO" >> $GITHUB_ENV
           else
             echo "This workflow was not triggered by a pull request. Continue with merge and update url in read me."
           fi

--- a/.github/workflows/run-verification.yml
+++ b/.github/workflows/run-verification.yml
@@ -78,11 +78,31 @@ jobs:
             fi
           fi
 
-          echo "$FILES"
-          echo "FILES=$FILES" >> $GITHUB_ENV
+                    
+          # we cannot set a multiline env vars so we must change it to single line (seperated by commas) if we have more than one file
+          if [ $(echo "$FILES" | wc -l) -gt 1 ]; then
+            # Replace newlines with a delimiter (e.g., comma)
+            FILES_SINGLE_LINE=$(echo "$FILES" | tr '\n' ',')
+          else
+            # Keep the original content without modification
+            FILES_SINGLE_LINE="$FILES"
+          fi
+
+          echo "$FILES_SINGLE_LINE"
+          echo "FILES_SINGLE_LINE=$FILES_SINGLE_LINE" >> $GITHUB_ENV
 
       - name: run layout verification
         run: |
+
+          # Check if there is a comma in the variable and revert it back to a multiline var
+          if [[ "$FILES_SINGLE_LINE" == *","* ]]; then
+            # Replace the delimiter with newlines
+            FILES=$(echo "$FILES_SINGLE_LINE" | tr ',' '\n')
+          else
+            # No comma found, keep the original content without modification
+            FILES="$FILES_SINGLE_LINE"
+          fi
+        
           # print the names of the files
           echo "Files for verification; $FILES"
 


### PR DESCRIPTION
- env var error arised because you cannot set env variable to a multiline string (i.e when there are multiple oas/gds files)
- download artifact error arised because the artifact only exists when the merge action is triggered after the verification action 
- both of these have now been fixed with the suggested changes below